### PR TITLE
Fix if no `<target>` element exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,13 @@ const translationTasks = files.map(file => {
                             const targetlatedText = isCdata
                                 ? `<![CDATA[${translatedTexts[i]}]]>`
                                 : `${translatedTexts[i]}`;
+                            // Check if target element exists, if not, create one
                             var target = $(node).find('target');
-                            target.html(targetlatedText);
+                            if (target.length === 0) {
+                                $(node).append(`<target>${targetlatedText}</target>`);
+                            } else {
+                                target.html(targetlatedText);
+                            }
                         });
                         fs.writeFileSync(outPath, $.xml());
                     })


### PR DESCRIPTION
Hi,
Cool project! Works really well.
Just one detail, I noticed that if no `<target>` element is present in the `.xliff` file calling `target.html()` doesn't work...

After translating, check if a <target> element exists. If not, create a new one with the translations as its content. Else, set the html for the existing one.